### PR TITLE
Namespace in rake file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,29 @@ You need:
 1. [Datadog API key](https://app.datadoghq.com/organization-settings/api-keys)
 2. and a [Datadog Application Key](https://app.datadoghq.com/organization-settings/application-keys)
 
-####  Configuration
+#### Add Rake Tasks
 
-If using in a Rails project, setup an initializer to configure the gem:
+Add the following to your Rakefile:
 
 ```ruby
-Datadog::ServiceCatalog.configure do |config|
-  config.datadog_api_key = '...'
-  config.datadog_application_key = '...'
-  config.markdown_file = 'service_catalog.md'
+require 'datadog/service_catalog/rake_tasks'
+
+namespace :service_catalog do
+  Datadog::ServiceCatalog.configure do |config|
+    config.datadog_api_key = '..'
+    config.datadog_application_key = '..'
+    config.markdown_file = 'service_info.md'
+  end
+  
+  Datadog::ServiceCatalog::RakeTasks::Validate.new
+	Datadog::ServiceCatalog::RakeTasks::UploadAll.new(['service_catalog:validate'])
 end
 ```
+
+This provides two new rake tasks: 
+
+1) `service_catalog:validate` - validate your service definition
+2) `service_catalog:upload_all` - upload service definitions for all `datadog_service_identifiers` 
 
 #### Front Matter Setup
 
@@ -50,20 +62,7 @@ tags:
 ---
 ```
 
-
-
-#### Rake
-
-Add the following to your Rakefile:
-
-```ruby
-require 'datadog/service_catalog/rake_tasks'
-
-Datadog::ServiceCatalog::RakeTasks::Validate.new
-Datadog::ServiceCatalog::RakeTasks::UploadAll.new('service_catalog', ['service_catalog:validate', :environment])
-```
-
-This provides two new rake tasks: 1) `service_catalog:validate`; 2) `service_catalog:upload_all`
+As you build your service definition, use `rake service_catalog:validate` to ensure it is valid. Once your definition is complete use `rake service_catalog:upload_all` to create or update your service catalog entries to DataDog.
 
 ### References
 

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ RuboCop::RakeTask.new
 
 RUBY_VERSIONS = '2.7, 3.0, 3.1'
 
-desc 'Run guard and spec for each supported ruby'
+desc 'Run rubocop and spec for each supported ruby'
 task :spec_all do
   RUBY_VERSIONS.split(',').map(&:strip).each do |ruby_version|
     puts "----- #{ruby_version} -----"

--- a/lib/datadog/service_catalog/rake_tasks/rake_task.rb
+++ b/lib/datadog/service_catalog/rake_tasks/rake_task.rb
@@ -14,7 +14,7 @@ module Datadog
         def initialize(task_dependencies = [], service_definition_klass: V2::ServiceDefinition)
           super()
           @service_definition_klass = service_definition_klass
-          @task_dependencies = task_dependencies
+          @task_dependencies = Array(task_dependencies)
           @verbose = true
 
           yield self if block_given?

--- a/lib/datadog/service_catalog/rake_tasks/rake_task.rb
+++ b/lib/datadog/service_catalog/rake_tasks/rake_task.rb
@@ -9,15 +9,10 @@ module Datadog
       # RakeTasks::RakeTask - base rake task for Service Catalog tasks
       #
       class RakeTask < ::Rake::TaskLib
-        attr_accessor :nspace, :task_dependencies, :verbose
+        attr_accessor :task_dependencies, :verbose
 
-        def initialize(
-          namespace = :service_catalog,
-          task_dependencies = [],
-          service_definition_klass = V2::ServiceDefinition
-        )
+        def initialize(task_dependencies = [], service_definition_klass = V2::ServiceDefinition)
           super()
-          @nspace = namespace
           @service_definition_klass = service_definition_klass
           @task_dependencies = task_dependencies
           @verbose = true

--- a/lib/datadog/service_catalog/rake_tasks/rake_task.rb
+++ b/lib/datadog/service_catalog/rake_tasks/rake_task.rb
@@ -11,7 +11,7 @@ module Datadog
       class RakeTask < ::Rake::TaskLib
         attr_accessor :task_dependencies, :verbose
 
-        def initialize(task_dependencies = [], service_definition_klass = V2::ServiceDefinition)
+        def initialize(task_dependencies = [], service_definition_klass: V2::ServiceDefinition)
           super()
           @service_definition_klass = service_definition_klass
           @task_dependencies = task_dependencies

--- a/lib/datadog/service_catalog/rake_tasks/upload_all.rb
+++ b/lib/datadog/service_catalog/rake_tasks/upload_all.rb
@@ -9,11 +9,9 @@ module Datadog
       #
       class UploadAll < RakeTask
         def define_task
-          namespace(nspace) do
-            desc 'Upload the ServiceDefinition for each service identifier'
-            task(upload_all: task_dependencies) do
-              service_definition_klass.new.upload_all
-            end
+          desc 'Upload the ServiceDefinition for each service identifier'
+          task(upload_all: task_dependencies) do
+            service_definition_klass.new.upload_all
           end
         end
       end

--- a/lib/datadog/service_catalog/rake_tasks/validate.rb
+++ b/lib/datadog/service_catalog/rake_tasks/validate.rb
@@ -9,13 +9,11 @@ module Datadog
       #
       class Validate < RakeTask
         def define_task
-          namespace(nspace) do
-            desc 'Upload the ServiceDefinition for each service identifier'
-            task(validate: task_dependencies) do
-              unless service_definition.valid?
-                puts formatted_error_msg
-                abort('The ServiceDefinition was not valid')
-              end
+          desc 'Validate the ServiceDefinition'
+          task(validate: task_dependencies) do
+            unless service_definition.valid?
+              puts formatted_error_msg
+              abort('The ServiceDefinition was not valid')
             end
           end
         end

--- a/spec/datadog/service_catalog/rake_tasks/upload_all_spec.rb
+++ b/spec/datadog/service_catalog/rake_tasks/upload_all_spec.rb
@@ -28,7 +28,7 @@ module Datadog
 
         describe 'running upload_all' do
           before do
-            described_class.new([], service_definition_klass)
+            described_class.new(service_definition_klass: service_definition_klass)
             Rake::Task['upload_all'].execute
           end
 

--- a/spec/datadog/service_catalog/rake_tasks/upload_all_spec.rb
+++ b/spec/datadog/service_catalog/rake_tasks/upload_all_spec.rb
@@ -22,14 +22,14 @@ module Datadog
 
         describe 'defining tasks' do
           it 'creates an upload_all task' do
-            expect(Rake::Task.task_defined?('service_catalog:upload_all')).to be true
+            expect(Rake::Task.task_defined?('upload_all')).to be true
           end
         end
 
         describe 'running upload_all' do
           before do
-            described_class.new(:service_catalog, [], service_definition_klass)
-            Rake::Task['service_catalog:upload_all'].execute
+            described_class.new([], service_definition_klass)
+            Rake::Task['upload_all'].execute
           end
 
           let(:service_definition_klass) { service_definition_klass_double(service_definition_instance_double) }

--- a/spec/datadog/service_catalog/rake_tasks/validate_spec.rb
+++ b/spec/datadog/service_catalog/rake_tasks/validate_spec.rb
@@ -20,14 +20,14 @@ module Datadog
 
         describe 'defining tasks' do
           it 'creates an validate task' do
-            expect(Rake::Task.task_defined?('service_catalog:validate')).to be true
+            expect(Rake::Task.task_defined?('validate')).to be true
           end
         end
 
         describe 'running upload_all' do
           before do
-            described_class.new(:service_catalog, [], service_definition_klass)
-            Rake::Task['service_catalog:validate'].execute
+            described_class.new([], service_definition_klass)
+            Rake::Task['validate'].execute
           end
 
           let(:service_definition_klass) { service_definition_klass_double(service_definition_instance_double) }

--- a/spec/datadog/service_catalog/rake_tasks/validate_spec.rb
+++ b/spec/datadog/service_catalog/rake_tasks/validate_spec.rb
@@ -26,7 +26,7 @@ module Datadog
 
         describe 'running upload_all' do
           before do
-            described_class.new([], service_definition_klass)
+            described_class.new(service_definition_klass: service_definition_klass)
             Rake::Task['validate'].execute
           end
 


### PR DESCRIPTION
### Changes

- Remove default namespace to support defining namespace in the Rakefile
- Allow rake task dependency args to be single OR array of dependencies
- Update docs to reflect new approach

Closes #1 